### PR TITLE
fix: Solves the problem of not being able to indepently install the typescript example

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -38,4 +38,8 @@ const project = new awscdk.AwsCdkConstructLibrary({
   copyrightOwner: "Merapar Technologies Group B.V.",
 });
 
+// Ensure the root tsconfig files do not apply to example/*
+project.tsconfig?.addExclude("examples/**");
+project.tsconfigDev?.addExclude("examples/**");
+
 project.synth();

--- a/examples/typescript/.gitignore
+++ b/examples/typescript/.gitignore
@@ -9,3 +9,6 @@ node_modules
 cdk.out
 
 dist/
+
+# The example does not use projen. So commit the tsconfig.json
+!tsconfig.json

--- a/examples/typescript/package-lock.json
+++ b/examples/typescript/package-lock.json
@@ -8,7 +8,7 @@
       "name": "ses-cloudwatch-example-typescript",
       "version": "0.1.0",
       "dependencies": {
-        "ses-cloudwatch": "file:../../"
+        "ses-cloudwatch": "latest"
       },
       "bin": {
         "ses-cloudwatch-example": "bin/app.js"
@@ -22,52 +22,16 @@
         "typescript": "^5.9.2"
       }
     },
-    "../..": {
-      "version": "0.0.0",
-      "license": "MIT",
-      "devDependencies": {
-        "@types/jest": "^30.0.0",
-        "@types/node": "^24.3.0",
-        "@typescript-eslint/eslint-plugin": "^8",
-        "@typescript-eslint/parser": "^8",
-        "aws-cdk-lib": "2.212.0",
-        "commit-and-tag-version": "^12",
-        "constructs": "10.0.5",
-        "eslint": "^9",
-        "eslint-config-prettier": "^10.1.8",
-        "eslint-import-resolver-typescript": "^4.4.4",
-        "eslint-plugin-import": "^2.32.0",
-        "eslint-plugin-prettier": "^5.5.4",
-        "jest": "^30.0.5",
-        "jest-junit": "^16",
-        "jsii": "~5.8.0",
-        "jsii-diff": "^1.113.0",
-        "jsii-docgen": "^10.5.0",
-        "jsii-pacmak": "^1.113.0",
-        "jsii-rosetta": "~5.8.0",
-        "prettier": "^3.6.2",
-        "projen": "^0.95.2",
-        "ts-jest": "^29.4.1",
-        "ts-node": "^10.9.2",
-        "typescript": "^5.9.2"
-      },
-      "peerDependencies": {
-        "aws-cdk-lib": "^2.212.0",
-        "constructs": "^10.0.5"
-      }
-    },
     "node_modules/@aws-cdk/asset-awscli-v1": {
       "version": "2.2.242",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.242.tgz",
       "integrity": "sha512-4c1bAy2ISzcdKXYS1k4HYZsNrgiwbiDzj36ybwFVxEWZXVAP0dimQTCaB9fxu7sWzEjw3d+eaw6Fon+QTfTIpQ==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz",
       "integrity": "sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
@@ -78,7 +42,6 @@
         "jsonschema",
         "semver"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "~1.4.1",
@@ -254,7 +217,6 @@
         "yaml",
         "mime-types"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "2.2.242",
@@ -626,7 +588,6 @@
       "version": "10.0.5",
       "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.0.5.tgz",
       "integrity": "sha512-IwOwekzrASFC3qt4ozCtV09rteAIAesuCGsW0p+uBfqHd2XcvA5CXqJjgf4eUqm6g8e/noXlVCMDWwC8GaLtrg==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 10.17.0"
@@ -672,8 +633,14 @@
       "license": "ISC"
     },
     "node_modules/ses-cloudwatch": {
-      "resolved": "../..",
-      "link": true
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ses-cloudwatch/-/ses-cloudwatch-1.1.0.tgz",
+      "integrity": "sha512-99+546yQsethEZ6dmAE/FMbrhIu4dVDBurCE9LMx8QxogNZFth87j1XrZt5/G0vRt7LXu1h/SEdUA/c4b/wEBg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.212.0",
+        "constructs": "^10.0.5"
+      }
     },
     "node_modules/ts-node": {
       "version": "10.9.2",

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -23,6 +23,6 @@
     "@types/node": "^22"
   },
   "dependencies": {
-    "ses-cloudwatch": "file:../../"
+    "ses-cloudwatch": "latest"
   }
 }

--- a/examples/typescript/tsconfig.json
+++ b/examples/typescript/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["es2022"],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "isolatedModules": true,
+    "typeRoots": ["./node_modules/@types"],
+    "outDir": "./build",
+    "rootDir": "./"
+  },
+  "exclude": ["node_modules", "cdk.out", "build"]
+}

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -32,6 +32,7 @@
     "projenrc/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "examples/**"
   ]
 }


### PR DESCRIPTION
Problem was that projen also tries to manage the example projects and writes the tsconfig for it. Now telling it not to do that  